### PR TITLE
Fixes for Linux kernel up to 3.16

### DIFF
--- a/lib/C/kernel/nf2_ethtool.c
+++ b/lib/C/kernel/nf2_ethtool.c
@@ -86,17 +86,11 @@ static void nf2_get_drvinfo(struct net_device *dev,
 
 }
 
-static int nf2_phys_id(struct net_device *dev, __u32 data)
-{
-	return 0;
-}
-
 static const struct ethtool_ops nf2_ethtool_ops = {
 	.get_settings		= nf2_get_settings,
 	.set_settings		= nf2_set_settings,
 	.get_drvinfo		= nf2_get_drvinfo,
 	.get_link		= ethtool_op_get_link,
-	.phys_id		= nf2_phys_id,
 };
 
 void nf2_set_ethtool_ops(struct net_device *dev)

--- a/lib/C/kernel/nf2_ethtool.c
+++ b/lib/C/kernel/nf2_ethtool.c
@@ -101,5 +101,5 @@ static const struct ethtool_ops nf2_ethtool_ops = {
 
 void nf2_set_ethtool_ops(struct net_device *dev)
 {
-	SET_ETHTOOL_OPS(dev, &nf2_ethtool_ops);
+	dev->ethtool_ops = &nf2_ethtool_ops;
 }


### PR DESCRIPTION
Please pull to fix building issues caused by changes in mainline Linux kernel. This pull includes fixes for changes made up to 3.16 version of Linux. All changes are trivial and will not cause problems on older versions of the kernel.
